### PR TITLE
Drop Node 10 in build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ 10.x, 12.x, 14.x ]
+        node: [ 12.x, 14.x ]
 
     name: Build and test [Node.js ${{ matrix.node }}]
     steps:


### PR DESCRIPTION
Parcel 2 nightly dropped support for Node 10 last week.
